### PR TITLE
Issue 35: Fix minor styling bugs in mobile nav menu

### DIFF
--- a/client/sharedComponents/NavMenu.jsx
+++ b/client/sharedComponents/NavMenu.jsx
@@ -46,7 +46,6 @@ const Menu = styled.div`
   position: fixed;
   top: 10px;
   box-sizing: border-box;
-  height: fit-content;
   width: ${menuWidth};
   background-color: white;
   padding: 20px;
@@ -60,7 +59,7 @@ const Menu = styled.div`
 
 const MenuHeader = styled.div`
   display: flex;
-  justify-content: right;
+  justify-content: flex-end;
   width: 100%;
   height: 18px;
   font-size: 18px;


### PR DESCRIPTION
Close issue #35:
- Aligns exit button to top-right of nav menu instead of top-left
- Removes excess padding from bottom of menu