### PR TITLE
Implementing custom split percentage feature

### DIFF
--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -318,7 +318,7 @@ const CostSharingForYnab = () => {
     setSelectedTransactions(isSelected ? [...transactionsInSharedCategories] : []);
   };
   
-  getOwedPercentage = (percentage) => {
+  const getOwedPercentage = (percentage) => {
     const owedPercentage = 1 - (percentage / 100);
     return owedPercentage;
   };
@@ -349,7 +349,7 @@ const CostSharingForYnab = () => {
     const summaryTransaction = {
       account_id: iouAccountId,
       date: convertDateToString(dateToSplitCosts),
-      amount: _.reduce(reducedCategorizedAmounts, (sum, amt) => sum - amt, 0),
+      amount: _.reduce(owedCategorizedAmounts, (sum, amt) => sum - amt, 0),
       payee_id: null,
       payee_name: null,
       category_id: null,
@@ -358,7 +358,7 @@ const CostSharingForYnab = () => {
       approved: true,
       flag_color: null,
       import_id: null,
-      subtransactions: _.map(reducedCategorizedAmounts, (amount, category_id) => ({
+      subtransactions: _.map(owedCategorizedAmounts, (amount, category_id) => ({
         amount: -(amount),
         payee_id: null,
         payee_name: 'Shared Costs',
@@ -602,14 +602,25 @@ const CostSharingForYnab = () => {
               <b>Select your share of the expenses (in percent):</b>
             </label>
             <input
-              type="number"
+              type="range"
               id="split-percentage-slider"
               min="1"
               max="99"
               value={myShare}
               onChange={(e) => setMyShare(e.target.value)}
             />
-            <span>%</span> 
+            <input
+              type="number"
+              min="1"
+              max="99"
+              value={myShare}
+              onChange={(e) => {
+                const value = Math.max(1, Math.min(99, e.target.value)); // Clamp value between 1 and 99 (no negative values)
+                setMyShare(value);
+              }}
+              style={{ marginLeft: '10px', width: '50px' }}
+            />
+            <span>%</span>   
           </RowOrColumn>
 
           <Spacer />

--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -204,7 +204,7 @@ const CostSharingForYnab = () => {
   });
   const [transactionsStartDate, setTransactionsStartDate] = useState(getFirstDateOfLastMonth());
   const [transactionsEndDate, setTransactionsEndDate] = useState(getLastDateOfLastMonth());
-  const [splitPercentage, setSplitPercentage] = useState(50);
+  const [myShare, setMyShare] = useState(50);
   const [selectedTransactions, setSelectedTransactions] = useState([]);
   const [dateToSplitCosts, setDateToSplitCosts] = useState(getLastDateOfLastMonth());
   const [classifiedTransactions, setClassifiedTransactions] = useState({});
@@ -340,7 +340,7 @@ const CostSharingForYnab = () => {
     const owedCategorizedAmounts = _.reduce(
       categorizedAmounts,
       (accum, amount, categoryId) => {
-      accum[categoryId] = Math.round(amount * getOwedPercentage(splitPercentage));
+      accum[categoryId] = Math.round(amount * getOwedPercentage(myShare));
       return accum;
       },
       {},
@@ -606,8 +606,8 @@ const CostSharingForYnab = () => {
               id="split-percentage-slider"
               min="1"
               max="99"
-              value={splitPercentage}
-              onChange={(e) => setSplitPercentage(e.target.value)}
+              value={myShare}
+              onChange={(e) => setMyShare(e.target.value)}
             />
             <span>%</span> 
           </RowOrColumn>

--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -318,7 +318,7 @@ const CostSharingForYnab = () => {
     setSelectedTransactions(isSelected ? [...transactionsInSharedCategories] : []);
   };
   
-  const handleSplitPercentageChange = (percentage) => {
+  getOwedPercentage = (percentage) => {
     const owedPercentage = 1 - (percentage / 100);
     return owedPercentage;
   };
@@ -337,10 +337,10 @@ const CostSharingForYnab = () => {
       {},
     );
 
-    const reducedCategorizedAmounts = _.reduce(
+    const owedCategorizedAmounts = _.reduce(
       categorizedAmounts,
       (accum, amount, categoryId) => {
-      accum[categoryId] = Math.round(amount * handleSplitPercentageChange(splitPercentage));
+      accum[categoryId] = Math.round(amount * getOwedPercentage(splitPercentage));
       return accum;
       },
       {},
@@ -592,14 +592,14 @@ const CostSharingForYnab = () => {
           <SectionHeader>Split the Total Cost</SectionHeader>
 
           <p>
-            Charge a percentage the shared costs to the &quot;IOU&quot;
+            Charge a percentage of the shared costs to the &quot;IOU&quot;
             account that shows what you are owed, and reduce
             your expenses by the same amount.
           </p>
 
           <RowOrColumn>
             <label htmlFor="split-percentage-slider">
-              <b>Select your share of the shared expenses (in percentage):</b>
+              <b>Select your share of the expenses (in percent):</b>
             </label>
             <input
               type="number"

--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -319,8 +319,8 @@ const CostSharingForYnab = () => {
   };
   
   const handleSplitPercentageChange = (percentage) => {
-    const partnerPercentage = 1 - (percentage / 100);
-    return partnerPercentage;
+    const owedPercentage = 1 - (percentage / 100);
+    return owedPercentage;
   };
 
   const createSplitEntry = async (e) => {
@@ -503,7 +503,7 @@ const CostSharingForYnab = () => {
 
         <SectionContent>
           <Subtitle>
-            Select the &quot;IOU&quot; account that shows what your partner owes you
+            Select the &quot;IOU&quot; account that shows what you are owed
           </Subtitle>
 
           <AccountSelector
@@ -593,7 +593,7 @@ const CostSharingForYnab = () => {
 
           <p>
             Charge a percentage the shared costs to the &quot;IOU&quot;
-            account that shows what your partner owes you, and reduce
+            account that shows what you are owed, and reduce
             your expenses by the same amount.
           </p>
 

--- a/client/landingPageSrc/LandingPage.jsx
+++ b/client/landingPageSrc/LandingPage.jsx
@@ -271,8 +271,8 @@ const LandingPage = () => {
 
             <DescriptionText>
               Cost Sharing for YNAB allows you to classify your transactions across any number
-              of categories, and then at the click of a button, remove other people's share of the
-              shared expenses from each category. No more doubled-up expenses or catch-all category!
+              of categories, and then at the click of a button, remove other people's share of the 
+              expenses from each category. No more doubled-up expenses or catch-all category!
             </DescriptionText>
           </DescriptionSection>
         </Description>

--- a/client/landingPageSrc/LandingPage.jsx
+++ b/client/landingPageSrc/LandingPage.jsx
@@ -258,7 +258,7 @@ const LandingPage = () => {
               A shared bank account or credit card is difficult to track in YNAB without
               your expenses appearing doubled. Maybe you&apos;ve resorted to excluding it
               from YNAB completely. Or, maybe you&apos;re throwing the costs into a blanket
-              &quot;shared expense&quot; category, and later splitting the total in half - which
+              &quot;shared expense&quot; category, and later splitting the total - which
               fixes the doubling problem, but masks where exactly the dollars are going.
             </DescriptionText>
           </DescriptionSection>
@@ -271,8 +271,8 @@ const LandingPage = () => {
 
             <DescriptionText>
               Cost Sharing for YNAB allows you to classify your transactions across any number
-              of categories, and then at the click of a button, pull half those costs out of
-              each one. No more doubled-up expenses or catch-all category!
+              of categories, and then at the click of a button, remove other people's share of the
+              shared expenses from each category. No more doubled-up expenses or catch-all category!
             </DescriptionText>
           </DescriptionSection>
         </Description>

--- a/client/shared/Instructions.jsx
+++ b/client/shared/Instructions.jsx
@@ -68,7 +68,7 @@ const Instructions = ({
     { text: 'Create a **parent** category in your YNAB budget named something like "Shared Expenses"' },
     { text: 'Add desired **sub-categories** underneath the "Shared Expenses" parent (such as rent, groceries, etc.)' },
     {
-      text: 'Add an **IOU account in YNAB:** this account will track what your partner owes you for their half of the credit card debt.',
+      text: 'Add an **IOU account in YNAB:** this account will track what you are owed for the shared the credit card debt.',
       subList: [
         { text: 'Click **Add Account** in YNAB' },
         { text: 'Select an account type of **Checking** (or Cash - this doesn\'t matter so much)' },
@@ -83,10 +83,10 @@ const Instructions = ({
       isHidden: !isHomePage,
     },
     {
-      text: 'The app will guide you through selecting your shared costs over a custom date range. Then it will create a single transaction **removing half the costs from your expenses,** and **adding the same amount to the IOU account you created,** reflecting the balance your partner owes you. You\'ll be able to see the transaction in YNAB, and delete or edit it if needed.',
+      text: 'The app will guide you through selecting your shared costs over a custom date range. Then it will ask you what is your share of the expenses (e.g. 50%). It will then create a single transaction **removing what you are owed from the expenses,** and **adding the same amount to the IOU account you created,** reflecting the balance you are owed. You\'ll be able to see the transaction in YNAB, and delete or edit it if needed.',
     },
     {
-      text: 'When your partner pays you back the balance, add a **transfer transaction** from the IOU account to the bank or cash account where you deposited the money. This will zero out the IOU account and make your bank account perfectly balanced, as all things should be!',
+      text: 'When you are paid back the balance you are owed, add a **transfer transaction** from the IOU account to the bank or cash account where you deposited the money. This will zero out the IOU account and make your bank account perfectly balanced, as all things should be!',
     },
   ];
 

--- a/client/shared/Instructions.jsx
+++ b/client/shared/Instructions.jsx
@@ -68,7 +68,7 @@ const Instructions = ({
     { text: 'Create a **parent** category in your YNAB budget named something like "Shared Expenses"' },
     { text: 'Add desired **sub-categories** underneath the "Shared Expenses" parent (such as rent, groceries, etc.)' },
     {
-      text: 'Add an **IOU account in YNAB:** this account will track what you are owed for the shared the credit card debt.',
+      text: 'Add an **IOU account in YNAB:** this account will track what you are owed for the shared credit card debt.',
       subList: [
         { text: 'Click **Add Account** in YNAB' },
         { text: 'Select an account type of **Checking** (or Cash - this doesn\'t matter so much)' },
@@ -83,7 +83,7 @@ const Instructions = ({
       isHidden: !isHomePage,
     },
     {
-      text: 'The app will guide you through selecting your shared costs over a custom date range. Then it will ask you what is your share of the expenses (e.g. 50%). It will then create a single transaction **removing what you are owed from the expenses,** and **adding the same amount to the IOU account you created,** reflecting the balance you are owed. You\'ll be able to see the transaction in YNAB, and delete or edit it if needed.',
+      text: 'The app will guide you through selecting your shared costs over a custom date range. Then it will ask you to specify your share of the expenses (e.g. 50%). It will then create a single transaction **removing what you are owed from the expenses,** and **adding the same amount to the IOU account you created,** reflecting the balance you are owed. You\'ll be able to see the transaction in YNAB, and delete or edit it if needed.',
     },
     {
       text: 'When you are paid back the balance you are owed, add a **transfer transaction** from the IOU account to the bank or cash account where you deposited the money. This will zero out the IOU account and make your bank account perfectly balanced, as all things should be!',


### PR DESCRIPTION
I've developed the feature requested on #1 . 

To keep things simple, the value of the custom split percentage input starts at a default value of 50% for users who were used to using the web app for splitting in half. I've also modified the instructions across the application to account for this change and to accommodate non-romantic use cases, like roommates or whatever other arrangement where people may use shared credit cards.