### PR TITLE
Allow 0%/100% split shares

### DIFF
--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -277,19 +277,22 @@ const CostSharingForYnab = () => {
 
   const getClassifiedTransactions = async ({ startDate, endDate }) => {
     const isTransactionATransfer = (transaction) => !!transaction.transfer_account_id;
-
+  
     try {
       setAreTransactionsLoading(true);
       const transactionsSinceStartDate = await getTransactionsSinceDate(startDate);
-
-      const displayedTransactions = transactionsSinceStartDate.filter((transaction) => (
-        isTransactionBeforeDate(transaction, endDate)
+  
+      // Filter transactions by selected shared accounts
+      const sharedAccountIds = selectedAccounts.map((acct) => acct.accountId);
+      const filteredTransactions = transactionsSinceStartDate.filter((transaction) => (
+        sharedAccountIds.includes(transaction.account_id)
+        && isTransactionBeforeDate(transaction, endDate)
         && transaction.approved
         && !isTransactionATransfer(transaction)
       ));
-
+  
       setClassifiedTransactions(classifyTransactions({
-        displayedTransactions,
+        displayedTransactions: filteredTransactions,
         selectedAccounts,
         selectedParentCategories,
       }));
@@ -604,8 +607,8 @@ const CostSharingForYnab = () => {
             <input
               type="range"
               id="split-percentage-slider"
-              min="1"
-              max="99"
+              min="0"
+              max="100"
               value={myShare}
               onChange={(e) => setMyShare(e.target.value)}
             />


### PR DESCRIPTION
This is for those times when you make a non-shared expense on the shared credit card (maybe because you get credit card rewards or you made a mistake). Current behaviour only allows 1%/99% division