### PR TITLE
Make it optional to select parent categories

### DIFF
--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -282,13 +282,16 @@ const CostSharingForYnab = () => {
       setAreTransactionsLoading(true);
       const transactionsSinceStartDate = await getTransactionsSinceDate(startDate);
 
+      const displayedTransactions = transactionsSinceStartDate.filter((transaction) => (
+        isTransactionBeforeDate(transaction, endDate)
+        && transaction.approved
+        && !isTransactionATransfer(transaction)
+      )).sort((a, b) => new Date(b.date) - new Date(a.date));
+
       setClassifiedTransactions(classifyTransactions({
-        transactions: transactionsSinceStartDate,
+        displayedTransactions,
         selectedAccounts,
         selectedParentCategories,
-        endDate,
-        isTransactionBeforeDate,
-        isTransactionATransfer,
       }));
     } catch (error) {
       setErrorData({
@@ -489,7 +492,10 @@ const CostSharingForYnab = () => {
         </SectionContent>
 
         <SectionContent>
-          <Subtitle>(Optional) If you track shared expenses under separate parent categories, select them here. This will turn on cross-checking for misclassified transactions.</Subtitle>
+          <Subtitle>
+            (Optional) If you track shared expenses under separate parent categories, select them
+            here. This will turn on cross-checking for misclassified transactions.
+          </Subtitle>
 
           <CategoryButtons
             parentCategories={budgetData.parentCategories}

--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -219,7 +219,7 @@ const CostSharingForYnab = () => {
   const [isSelectAllChecked, setIsSelectAllChecked] = useState(false);
 
   const {
-    transactionsInSharedCategories = [],
+    filteredTransactions = [],
     sharedAccountErrorTransactions = [],
     sharedCategoryErrorTransactions = [],
   } = classifiedTransactions;
@@ -334,7 +334,7 @@ const CostSharingForYnab = () => {
 
   const toggleSelectAll = ({ isSelected }) => {
     setIsSelectAllChecked(isSelected);
-    setSelectedTransactions(isSelected ? [...transactionsInSharedCategories] : []);
+    setSelectedTransactions(isSelected ? [...filteredTransactions] : []);
   };
 
   const getOwedPercentage = (percentage) => {
@@ -594,7 +594,7 @@ const CostSharingForYnab = () => {
         <TransactionWindowContainer>
           <TransactionWindow
             loading={areTransactionsLoading}
-            transactions={transactionsInSharedCategories}
+            transactions={filteredTransactions}
             selectedTransactions={selectedTransactions}
             transactionsSharedInOneButNotOther={sharedCategoryErrorTransactions}
             toggleTransactionSelection={toggleTransactionSelection}

--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -511,7 +511,7 @@ const CostSharingForYnab = () => {
         </SectionContent>
 
         <SectionContent>
-          <Subtitle>(Optional) Select the YNAB parent category(ies) where you track shared expenses</Subtitle>
+          <Subtitle>(Optional) If you track shared expenses under separate parent categories, select them here. This will turn on cross-checking for misclassified transactions.</Subtitle>
 
           <CategoryButtons
             parentCategories={budgetData.parentCategories}

--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -282,35 +282,13 @@ const CostSharingForYnab = () => {
       setAreTransactionsLoading(true);
       const transactionsSinceStartDate = await getTransactionsSinceDate(startDate);
 
-      let displayedTransactions;
-
-      if (selectedParentCategories.length === 0) {
-        // No parent categories: filter by selected accounts only
-        displayedTransactions = transactionsSinceStartDate.filter((transaction) => (
-          isTransactionBeforeDate(transaction, endDate)
-          && transaction.approved
-          && !isTransactionATransfer(transaction)
-          && selectedAccounts.some((acct) => acct.accountId === transaction.account_id)
-        )).sort((a, b) => new Date(b.date) - new Date(a.date));
-      } else {
-        // Parent categories selected: filter by category, ignore account
-        // Get all subcategory IDs from selected parent categories
-        const sharedCategoryIds = selectedParentCategories
-          .flatMap(({ subCategories }) => subCategories)
-          .map((cat) => cat.id);
-
-        displayedTransactions = transactionsSinceStartDate.filter((transaction) => (
-          isTransactionBeforeDate(transaction, endDate)
-          && transaction.approved
-          && !isTransactionATransfer(transaction)
-          && sharedCategoryIds.includes(transaction.category_id)
-        )).sort((a, b) => new Date(b.date) - new Date(a.date));;
-        }
-
       setClassifiedTransactions(classifyTransactions({
-        displayedTransactions,
+        transactions: transactionsSinceStartDate,
         selectedAccounts,
         selectedParentCategories,
+        endDate,
+        isTransactionBeforeDate,
+        isTransactionATransfer,
       }));
     } catch (error) {
       setErrorData({

--- a/client/appSrc/components/CostSharingForYnab.jsx
+++ b/client/appSrc/components/CostSharingForYnab.jsx
@@ -282,10 +282,12 @@ const CostSharingForYnab = () => {
       setAreTransactionsLoading(true);
       const transactionsSinceStartDate = await getTransactionsSinceDate(startDate);
 
-      const displayedTransactions = transactionsSinceStartDate.filter((transaction) => (
+      // Only filter by category if any parent categories are selected
+      let displayedTransactions = transactionsSinceStartDate.filter((transaction) => (
         isTransactionBeforeDate(transaction, endDate)
         && transaction.approved
         && !isTransactionATransfer(transaction)
+        && selectedAccounts.some((acct) => acct.accountId === transaction.account_id)
       )).sort((a, b) => new Date(b.date) - new Date(a.date));
 
       setClassifiedTransactions(classifyTransactions({
@@ -492,7 +494,7 @@ const CostSharingForYnab = () => {
         </SectionContent>
 
         <SectionContent>
-          <Subtitle>Select the YNAB parent category(ies) where you track shared expenses</Subtitle>
+          <Subtitle>(Optional) Select the YNAB parent category(ies) where you track shared expenses</Subtitle>
 
           <CategoryButtons
             parentCategories={budgetData.parentCategories}

--- a/client/appSrc/components/utils/classifyTransactions.js
+++ b/client/appSrc/components/utils/classifyTransactions.js
@@ -3,9 +3,12 @@
 import { toId } from './general';
 
 const classifyTransactions = ({
-  displayedTransactions,
+  transactions,
   selectedAccounts,
   selectedParentCategories,
+  endDate,
+  isTransactionBeforeDate,
+  isTransactionATransfer,
 }) => {
   const sharedAccountIds = selectedAccounts.map((acct) => acct.accountId);
   const sharedCategoryIds = selectedParentCategories.length > 0
@@ -13,6 +16,23 @@ const classifyTransactions = ({
         .flatMap(({ subCategories }) => subCategories)
         .map(toId)
     : [];
+
+  let displayedTransactions;
+  if (selectedParentCategories.length === 0) {
+    displayedTransactions = transactions.filter((transaction) => (
+      isTransactionBeforeDate(transaction, endDate)
+      && transaction.approved
+      && !isTransactionATransfer(transaction)
+      && sharedAccountIds.includes(transaction.account_id)
+    )).sort((a, b) => new Date(b.date) - new Date(a.date));
+  } else {
+    displayedTransactions = transactions.filter((transaction) => (
+      isTransactionBeforeDate(transaction, endDate)
+      && transaction.approved
+      && !isTransactionATransfer(transaction)
+      && sharedCategoryIds.includes(transaction.category_id)
+    )).sort((a, b) => new Date(b.date) - new Date(a.date));
+  }
 
   if (sharedCategoryIds.length === 0) {
     return {
@@ -23,10 +43,7 @@ const classifyTransactions = ({
   }
 
   return displayedTransactions.reduce((accum, transaction) => {
-    const {
-      account_id,
-      category_id,
-    } = transaction;
+    const { account_id, category_id } = transaction;
 
     const isInSharedAccount = sharedAccountIds.includes(account_id);
     const isInSharedCategory = sharedCategoryIds.includes(category_id);

--- a/client/appSrc/components/utils/classifyTransactions.js
+++ b/client/appSrc/components/utils/classifyTransactions.js
@@ -8,9 +8,20 @@ const classifyTransactions = ({
   selectedParentCategories,
 }) => {
   const sharedAccountIds = selectedAccounts.map((acct) => acct.accountId);
-  const sharedCategoryIds = selectedParentCategories
-    .flatMap(({ subCategories }) => subCategories)
-    .map(toId);
+  const sharedCategoryIds = selectedParentCategories.length > 0
+    ? selectedParentCategories
+        .flatMap(({ subCategories }) => subCategories)
+        .map(toId)
+    : [];
+
+  // If no parent categories selected, treat all as "in shared categories"
+  if (sharedCategoryIds.length === 0) {
+    return {
+      transactionsInSharedCategories: displayedTransactions,
+      sharedAccountErrorTransactions: [],
+      sharedCategoryErrorTransactions: [],
+    };
+  }
 
   return displayedTransactions.reduce((accum, transaction) => {
     const {

--- a/client/appSrc/components/utils/classifyTransactions.js
+++ b/client/appSrc/components/utils/classifyTransactions.js
@@ -14,10 +14,9 @@ const classifyTransactions = ({
         .map(toId)
     : [];
 
-  // If no parent categories selected, treat all as "in shared categories"
   if (sharedCategoryIds.length === 0) {
     return {
-      transactionsInSharedCategories: displayedTransactions,
+      filteredTransactions: displayedTransactions,
       sharedAccountErrorTransactions: [],
       sharedCategoryErrorTransactions: [],
     };
@@ -34,13 +33,13 @@ const classifyTransactions = ({
     const isInSharedAccountButNotCategory = isInSharedAccount && !isInSharedCategory;
     const isInSharedCategoryButNotAccount = isInSharedCategory && !isInSharedAccount;
 
-    if (isInSharedCategory) accum.transactionsInSharedCategories.push(transaction);
+    if (isInSharedCategory) accum.filteredTransactions.push(transaction);
     if (isInSharedAccountButNotCategory) accum.sharedAccountErrorTransactions.push(transaction);
     if (isInSharedCategoryButNotAccount) accum.sharedCategoryErrorTransactions.push(transaction);
 
     return accum;
   }, {
-    transactionsInSharedCategories: [],
+    filteredTransactions: [],
     sharedAccountErrorTransactions: [],
     sharedCategoryErrorTransactions: [],
   });


### PR DESCRIPTION
Based on the discussions on #54, I want to propose a change to how the listed transactions are filtered.

The idea is to make the second step of the flow (selecting parent categories where you have shared expenses) optional to also cater to users that don't track their shared expenses with categories. So if no parent categories are selected, a complete list of the transactions from the shared account gets listed (which to me seems more intuitive). Else, if one or more parent categories are selected, the current behaviour of the app is maintained (listing all transactions from the selected parent categories, regardless of selected account) to give users visibility of a transaction placed on the wrong account.

This PR invalidates #56 IMO, since its only purpose was to streamline the use for people who don't use categories to track shared expenses, so I'll be closing it.